### PR TITLE
Add 1D Rule 110 implementation

### DIFF
--- a/ca_rules/rule_110.py
+++ b/ca_rules/rule_110.py
@@ -1,0 +1,34 @@
+# ca_rules/rule_110.py
+
+import numpy as np
+
+def rule_110(grid, neighbor_count=None, num_states=2):
+    """
+    Implements 1D Wolfram Rule 110.
+    Assumes binary state (0/1) and 1D grid.
+    """
+    extended = np.pad(grid, pad_width=1, mode='wrap')
+    new_grid = np.zeros_like(grid)
+
+    for i in range(len(grid)):
+        left = extended[i]
+        center = extended[i+1]
+        right = extended[i+2]
+        triplet = (left << 2) | (center << 1) | right
+        new_grid[i] = rule_110_lookup[triplet]
+
+    return new_grid
+
+# Binary: 01101110
+# Triplet → new state
+rule_110_lookup = {
+    0b111: 0,
+    0b110: 1,
+    0b101: 1,
+    0b100: 0,
+    0b011: 1,
+    0b010: 1,
+    0b001: 1,
+    0b000: 0,
+}
+

--- a/scripts/pattern_analysis.py
+++ b/scripts/pattern_analysis.py
@@ -1,0 +1,32 @@
+# scripts/pattern_analysis.py
+
+from src.ca_core import CellularAutomaton
+from src.models.game_of_life import game_of_life_rule
+from utils.visualize import plot_grid
+from utils.metrics import temporal_entropy, symmetry_score
+
+import matplotlib.pyplot as plt
+
+def main():
+    print("[*] Running Game of Life for 100 steps...")
+    ca = CellularAutomaton(grid_size=(50, 50), rule_fn=game_of_life_rule, dim=2)
+    history = ca.run(steps=100)
+
+    print("[*] Plotting entropy over time...")
+    entropies = temporal_entropy(history)
+    plt.plot(entropies)
+    plt.title("Entropy Over Time")
+    plt.xlabel("Step")
+    plt.ylabel("Shannon Entropy")
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+    print("[*] Computing symmetry of final grid...")
+    sym = symmetry_score(history[-1])
+    print(f"Final symmetry score: {sym:.2f}")
+    plot_grid(history[-1], title=f"Final Grid (Symmetry: {sym:.2f})")
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
This PR introduces `rule_110.py` under `ca_rules/`. Rule 110 is a binary, 1D cellular automaton known for its computational universality and Class IV behavior. 

- Implements left-center-right triplet logic
- Compatible with the `dim=1` mode in `ca_core.py`
