### PR TITLE
Add reaction diffusion gray scott

### DIFF
--- a/ca_rules/rule_110.py
+++ b/ca_rules/rule_110.py
@@ -1,0 +1,34 @@
+# ca_rules/rule_110.py
+
+import numpy as np
+
+def rule_110(grid, neighbor_count=None, num_states=2):
+    """
+    Implements 1D Wolfram Rule 110.
+    Assumes binary state (0/1) and 1D grid.
+    """
+    extended = np.pad(grid, pad_width=1, mode='wrap')
+    new_grid = np.zeros_like(grid)
+
+    for i in range(len(grid)):
+        left = extended[i]
+        center = extended[i+1]
+        right = extended[i+2]
+        triplet = (left << 2) | (center << 1) | right
+        new_grid[i] = rule_110_lookup[triplet]
+
+    return new_grid
+
+# Binary: 01101110
+# Triplet → new state
+rule_110_lookup = {
+    0b111: 0,
+    0b110: 1,
+    0b101: 1,
+    0b100: 0,
+    0b011: 1,
+    0b010: 1,
+    0b001: 1,
+    0b000: 0,
+}
+

--- a/ca_rules/rule_90.py
+++ b/ca_rules/rule_90.py
@@ -1,0 +1,18 @@
+# ca_rules/rule_90.py
+
+import numpy as np
+
+def rule_90(grid, neighbor_count=None, num_states=2):
+    """
+    Rule 90: binary 1D CA using XOR of left and right neighbors.
+    """
+    extended = np.pad(grid, pad_width=1, mode='wrap')
+    new_grid = np.zeros_like(grid)
+
+    for i in range(len(grid)):
+        left = extended[i]
+        right = extended[i+2]
+        new_grid[i] = left ^ right  # XOR
+
+    return new_grid
+

--- a/scripts/compare_rules.py
+++ b/scripts/compare_rules.py
@@ -1,0 +1,50 @@
+# scripts/compare_rules.py
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from ca_rules.wolfram_rule_30 import wolfram_rule_30
+from ca_rules.rule_110 import rule_110
+from ca_rules.rule_90 import rule_90
+
+from src.ca_core import CellularAutomaton
+from utils.metrics import temporal_entropy, activity_score
+
+def run_1d_rule(rule_fn, steps=100, width=101):
+    ca = CellularAutomaton(grid_size=width, rule_fn=rule_fn, dim=1)
+    return ca.run(steps)
+
+def plot_metric_curves(metric_fn, histories, labels, title, ylabel):
+    plt.figure(figsize=(8, 5))
+    for history, label in zip(histories, labels):
+        curve = metric_fn(history)
+        plt.plot(curve, label=label)
+    plt.title(title)
+    plt.xlabel("Step")
+    plt.ylabel(ylabel)
+    plt.legend()
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+def main():
+    steps = 100
+    print("[*] Running Rule 30, 110, 90...")
+    h_30 = run_1d_rule(wolfram_rule_30, steps)
+    h_110 = run_1d_rule(rule_110, steps)
+    h_90 = run_1d_rule(rule_90, steps)
+
+    histories = [h_30, h_110, h_90]
+    labels = ["Rule 30", "Rule 110", "Rule 90"]
+
+    print("[*] Plotting entropy over time...")
+    plot_metric_curves(temporal_entropy, histories, labels, title="Entropy Over Time", ylabel="Entropy")
+
+    print("[*] Plotting activity scores...")
+    activity_scores = [activity_score(h) for h in histories]
+    for label, score in zip(labels, activity_scores):
+        print(f"{label} average activity: {score:.2f}")
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/pattern_analysis.py
+++ b/scripts/pattern_analysis.py
@@ -1,0 +1,32 @@
+# scripts/pattern_analysis.py
+
+from src.ca_core import CellularAutomaton
+from src.models.game_of_life import game_of_life_rule
+from utils.visualize import plot_grid
+from utils.metrics import temporal_entropy, symmetry_score
+
+import matplotlib.pyplot as plt
+
+def main():
+    print("[*] Running Game of Life for 100 steps...")
+    ca = CellularAutomaton(grid_size=(50, 50), rule_fn=game_of_life_rule, dim=2)
+    history = ca.run(steps=100)
+
+    print("[*] Plotting entropy over time...")
+    entropies = temporal_entropy(history)
+    plt.plot(entropies)
+    plt.title("Entropy Over Time")
+    plt.xlabel("Step")
+    plt.ylabel("Shannon Entropy")
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+    print("[*] Computing symmetry of final grid...")
+    sym = symmetry_score(history[-1])
+    print(f"Final symmetry score: {sym:.2f}")
+    plot_grid(history[-1], title=f"Final Grid (Symmetry: {sym:.2f})")
+
+if __name__ == "__main__":
+    main()
+

--- a/src/models/continuous_diffusion.py
+++ b/src/models/continuous_diffusion.py
@@ -1,0 +1,26 @@
+# src/models/continuous_diffusion.py
+
+import numpy as np
+from scipy.ndimage import convolve
+
+def continuous_diffusion_rule(grid, neighbor_count=None, num_states=None):
+    """
+    Each cell holds a float state between 0 and 1.
+    Update = diffusion + decay.
+
+    - Uses a 3x3 Gaussian-like kernel
+    - Models diffusion of a signal (e.g., morphogen or voltage)
+    """
+
+    kernel = np.array([
+        [0.05, 0.1, 0.05],
+        [0.1,  0.4, 0.1],
+        [0.05, 0.1, 0.05]
+    ])
+
+    diffused = convolve(grid, kernel, mode='wrap')
+    decayed = diffused * 0.98  # simple decay
+
+    # Clamp values to [0, 1]
+    return np.clip(decayed, 0, 1)
+

--- a/src/models/multistate_wave.py
+++ b/src/models/multistate_wave.py
@@ -1,0 +1,27 @@
+# src/models/multistate_wave.py
+
+import numpy as np
+
+def multistate_wave_rule(grid, neighbor_count, num_states):
+    """
+    A simple 3-state excitable medium rule:
+    - 0 = resting
+    - 1 = excited
+    - 2 = refractory
+
+    Rules:
+    - Resting cell becomes excited if >= 1 excited neighbor
+    - Excited → Refractory
+    - Refractory → Resting
+    """
+    new_grid = np.copy(grid)
+
+    excited_neighbors = (neighbor_count >= 1)
+
+    # Rule transitions
+    new_grid[(grid == 0) & excited_neighbors] = 1     # Resting → Excited
+    new_grid[(grid == 1)] = 2                         # Excited → Refractory
+    new_grid[(grid == 2)] = 0                         # Refractory → Resting
+
+    return new_grid
+

--- a/src/models/reaction_diffusion.py
+++ b/src/models/reaction_diffusion.py
@@ -1,0 +1,42 @@
+# src/models/reaction_diffusion.py
+
+import numpy as np
+from scipy.ndimage import convolve
+
+def reaction_diffusion_rule(grid, neighbor_count=None, num_states=None):
+    """
+    Gray-Scott-like reaction-diffusion system:
+    Two chemicals, U and V, diffuse and react:
+    - U diffuses slowly and feeds V
+    - V diffuses faster and decays
+
+    grid: 3D array of shape (H, W, 2) with channels [U, V]
+    """
+    U = grid[..., 0]
+    V = grid[..., 1]
+
+    # Diffusion kernels (Laplacian-style)
+    kernel = np.array([
+        [0.05, 0.2, 0.05],
+        [0.2, -1.0, 0.2],
+        [0.05, 0.2, 0.05]
+    ])
+
+    dU = convolve(U, kernel, mode='wrap')
+    dV = convolve(V, kernel, mode='wrap')
+
+    # Reaction-diffusion parameters (tweakable)
+    Du, Dv = 0.16, 0.8
+    F, k = 0.060, 0.062
+
+    # Gray-Scott reaction equations
+    reaction = U * V**2
+    U_new = U + (Du * dU - reaction + F * (1 - U))
+    V_new = V + (Dv * dV + reaction - (F + k) * V)
+
+    # Clamp values to [0, 1]
+    U_new = np.clip(U_new, 0, 1)
+    V_new = np.clip(V_new, 0, 1)
+
+    return np.stack([U_new, V_new], axis=-1)
+


### PR DESCRIPTION
This PR introduces a Gray-Scott reaction-diffusion model in `reaction_diffusion.py`. The model:

- Tracks two float-valued fields: U (activator) and V (inhibitor)
- Applies discrete diffusion + nonlinear reaction terms
- Produces complex, emergent Turing-like patterns

Compatible with `ca_core.py` using dim=2 and a 3D state grid (H, W, 2).
