### PR TITLE
Add wolfram auto labels

### DIFF
--- a/ca_rules/rule_110.py
+++ b/ca_rules/rule_110.py
@@ -1,0 +1,34 @@
+# ca_rules/rule_110.py
+
+import numpy as np
+
+def rule_110(grid, neighbor_count=None, num_states=2):
+    """
+    Implements 1D Wolfram Rule 110.
+    Assumes binary state (0/1) and 1D grid.
+    """
+    extended = np.pad(grid, pad_width=1, mode='wrap')
+    new_grid = np.zeros_like(grid)
+
+    for i in range(len(grid)):
+        left = extended[i]
+        center = extended[i+1]
+        right = extended[i+2]
+        triplet = (left << 2) | (center << 1) | right
+        new_grid[i] = rule_110_lookup[triplet]
+
+    return new_grid
+
+# Binary: 01101110
+# Triplet → new state
+rule_110_lookup = {
+    0b111: 0,
+    0b110: 1,
+    0b101: 1,
+    0b100: 0,
+    0b011: 1,
+    0b010: 1,
+    0b001: 1,
+    0b000: 0,
+}
+

--- a/ca_rules/rule_90.py
+++ b/ca_rules/rule_90.py
@@ -1,0 +1,18 @@
+# ca_rules/rule_90.py
+
+import numpy as np
+
+def rule_90(grid, neighbor_count=None, num_states=2):
+    """
+    Rule 90: binary 1D CA using XOR of left and right neighbors.
+    """
+    extended = np.pad(grid, pad_width=1, mode='wrap')
+    new_grid = np.zeros_like(grid)
+
+    for i in range(len(grid)):
+        left = extended[i]
+        right = extended[i+2]
+        new_grid[i] = left ^ right  # XOR
+
+    return new_grid
+

--- a/docs/model_comparisons.md
+++ b/docs/model_comparisons.md
@@ -1,0 +1,59 @@
+# 🔬 Visual Comparison of Cellular Automata Models
+
+This document provides visual outputs of various 1D and 2D cellular automata supported in the project.
+
+---
+
+## Rule 30 (1D)
+
+- Behavior: Chaotic, random-looking pattern from a simple rule
+- Wolfram Class: III (chaotic)
+
+![Rule 30](assets/rule_30.gif)
+
+---
+
+## Rule 90 (1D)
+
+- Behavior: Deterministic fractals (Sierpiński triangle)
+- Wolfram Class: II (periodic)
+
+![Rule 90](assets/rule_90.gif)
+
+---
+
+## Rule 110 (1D)
+
+- Behavior: Complex structures, Turing complete
+- Wolfram Class: IV (edge of chaos)
+
+![Rule 110](assets/rule_110.gif)
+
+---
+
+## Game of Life (2D)
+
+- Behavior: Gliders, oscillators, chaotic growth
+- Wolfram Class: IV
+
+![Game of Life](assets/game_of_life.gif)
+
+---
+
+## Reaction-Diffusion (Gray-Scott)
+
+- Behavior: Turing-like patterns from chemical interactions
+- Used for: Modeling skin, coats, morphogenesis
+
+![Reaction-Diffusion](assets/reaction_diffusion.gif)
+
+---
+
+## How These Were Generated
+
+Run each model with `runner.py` and `--save-video`:
+
+```bash
+python runner.py --model rule_30 --steps 100 --dim 1 --save-video docs/assets/rule_30.gif
+python runner.py --model game_of_life --steps 200 --save-video docs/assets/game_of_life.gif
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+umap-learn
+scikit-learn
+matplotlib
+

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,67 @@
+# runner.py
+
+import argparse
+import numpy as np
+
+from src.ca_core import CellularAutomaton
+from utils.visualize import animate_history
+
+# Import all rule functions here
+from ca_rules.wolfram_rule_30 import wolfram_rule_30
+from ca_rules.rule_110 import rule_110
+from ca_rules.rule_90 import rule_90
+from src.models.game_of_life import game_of_life_rule
+from src.models.snail_sim import snail_shell_rule
+from src.models.embryo_diffusion import embryo_diffusion_rule
+from src.models.multistate_wave import multistate_wave_rule
+from src.models.continuous_diffusion import continuous_diffusion_rule
+from src.models.reaction_diffusion import reaction_diffusion_rule
+
+# Map CLI names to functions
+MODEL_REGISTRY = {
+    "rule_30": wolfram_rule_30,
+    "rule_90": rule_90,
+    "rule_110": rule_110,
+    "game_of_life": game_of_life_rule,
+    "snail": snail_shell_rule,
+    "embryo": embryo_diffusion_rule,
+    "wave": multistate_wave_rule,
+    "diffusion": continuous_diffusion_rule,
+    "reaction_diffusion": reaction_diffusion_rule
+}
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a cellular automaton model.")
+    parser.add_argument("--model", type=str, required=True, choices=MODEL_REGISTRY.keys())
+    parser.add_argument("--steps", type=int, default=100)
+    parser.add_argument("--size", type=int, default=100)
+    parser.add_argument("--dim", type=int, choices=[1, 2], default=2)
+    parser.add_argument("--cmap", type=str, default="binary")
+    args = parser.parse_args()
+
+    rule_fn = MODEL_REGISTRY[args.model]
+
+    print(f"[*] Running model: {args.model} for {args.steps} steps...")
+
+    if args.model == "reaction_diffusion":
+        U = np.ones((args.size, args.size))
+        V = np.zeros((args.size, args.size))
+        V[args.size // 2 - 5:args.size // 2 + 5, args.size // 2 - 5:args.size // 2 + 5] = 1.0
+        initial_grid = np.stack([U, V], axis=-1)
+        ca = CellularAutomaton((args.size, args.size), rule_fn, dim=2)
+        ca.grid = initial_grid
+    elif args.dim == 1:
+        ca = CellularAutomaton(args.size, rule_fn, dim=1)
+    else:
+        ca = CellularAutomaton((args.size, args.size), rule_fn, dim=2)
+
+    history = ca.run(args.steps)
+
+    if args.model == "reaction_diffusion":
+        animate_history(history[..., 1], cmap=args.cmap)
+    else:
+        animate_history(history, cmap=args.cmap)
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/classify_behavior.py
+++ b/scripts/classify_behavior.py
@@ -1,0 +1,77 @@
+# scripts/classify_behavior.py
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from ca_rules.wolfram_rule_30 import wolfram_rule_30
+from ca_rules.rule_110 import rule_110
+from ca_rules.rule_90 import rule_90
+from src.models.game_of_life import game_of_life_rule
+from utils.metrics import temporal_entropy, activity_score, symmetry_score
+from src.ca_core import CellularAutomaton
+
+from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler
+from sklearn.decomposition import PCA
+from sklearn.pipeline import make_pipeline
+
+# --- Setup rules and true class labels ---
+RULES = {
+    "rule_30": (wolfram_rule_30, 3),        # Chaotic (Class III)
+    "rule_90": (rule_90, 2),                # Fractal / Periodic (Class II)
+    "rule_110": (rule_110, 4),              # Complex (Class IV)
+    "gol": (game_of_life_rule, 4),          # Complex (Class IV)
+}
+
+# --- Helper: extract features from a CA history ---
+def extract_features(history):
+    entropy_curve = temporal_entropy(history)
+    entropy_mean = np.mean(entropy_curve)
+    activity = activity_score(history)
+    symmetry = symmetry_score(history[-1])
+    return [entropy_mean, activity, symmetry]
+
+# --- Step 1: Generate dataset ---
+X = []
+y = []
+
+print("[*] Simulating models and extracting features...")
+
+for name, (rule_fn, class_label) in RULES.items():
+    for _ in range(10):  # multiple runs per rule
+        if name in {"rule_30", "rule_90", "rule_110"}:
+            ca = CellularAutomaton(grid_size=101, rule_fn=rule_fn, dim=1)
+        else:
+            ca = CellularAutomaton(grid_size=(50, 50), rule_fn=rule_fn, dim=2)
+
+        history = ca.run(steps=100)
+        features = extract_features(history)
+        X.append(features)
+        y.append(class_label)
+
+X = np.array(X)
+y = np.array(y)
+
+# --- Step 2: Train classifier ---
+print("[*] Training classifier...")
+clf = make_pipeline(StandardScaler(), LogisticRegression(multi_class="multinomial", solver="lbfgs"))
+clf.fit(X, y)
+accuracy = clf.score(X, y)
+print(f"[✓] Training accuracy: {accuracy:.2f}")
+
+# --- Step 3: Visualize PCA space ---
+print("[*] Visualizing in PCA-reduced space...")
+
+pca = PCA(n_components=2)
+X_pca = pca.fit_transform(X)
+
+plt.figure(figsize=(8, 6))
+scatter = plt.scatter(X_pca[:, 0], X_pca[:, 1], c=y, cmap="viridis", s=80, edgecolor="k")
+plt.title("Wolfram Class Clustering via PCA of CA Dynamics")
+plt.xlabel("PC1")
+plt.ylabel("PC2")
+plt.grid(True)
+plt.colorbar(scatter, label="Wolfram Class")
+plt.tight_layout()
+plt.show()
+

--- a/scripts/compare_rules.py
+++ b/scripts/compare_rules.py
@@ -1,0 +1,50 @@
+# scripts/compare_rules.py
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from ca_rules.wolfram_rule_30 import wolfram_rule_30
+from ca_rules.rule_110 import rule_110
+from ca_rules.rule_90 import rule_90
+
+from src.ca_core import CellularAutomaton
+from utils.metrics import temporal_entropy, activity_score
+
+def run_1d_rule(rule_fn, steps=100, width=101):
+    ca = CellularAutomaton(grid_size=width, rule_fn=rule_fn, dim=1)
+    return ca.run(steps)
+
+def plot_metric_curves(metric_fn, histories, labels, title, ylabel):
+    plt.figure(figsize=(8, 5))
+    for history, label in zip(histories, labels):
+        curve = metric_fn(history)
+        plt.plot(curve, label=label)
+    plt.title(title)
+    plt.xlabel("Step")
+    plt.ylabel(ylabel)
+    plt.legend()
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+def main():
+    steps = 100
+    print("[*] Running Rule 30, 110, 90...")
+    h_30 = run_1d_rule(wolfram_rule_30, steps)
+    h_110 = run_1d_rule(rule_110, steps)
+    h_90 = run_1d_rule(rule_90, steps)
+
+    histories = [h_30, h_110, h_90]
+    labels = ["Rule 30", "Rule 110", "Rule 90"]
+
+    print("[*] Plotting entropy over time...")
+    plot_metric_curves(temporal_entropy, histories, labels, title="Entropy Over Time", ylabel="Entropy")
+
+    print("[*] Plotting activity scores...")
+    activity_scores = [activity_score(h) for h in histories]
+    for label, score in zip(labels, activity_scores):
+        print(f"{label} average activity: {score:.2f}")
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/generate_dataset.py
+++ b/scripts/generate_dataset.py
@@ -1,0 +1,58 @@
+# scripts/generate_dataset.py
+
+import numpy as np
+import pandas as pd
+from src.ca_core import CellularAutomaton
+from utils.metrics import temporal_entropy, activity_score, symmetry_score
+
+def make_rule_fn(rule_number):
+    """
+    Generate a rule function for a given elementary rule number (0–255)
+    """
+    binary = np.array([int(x) for x in np.binary_repr(rule_number, width=8)], dtype=np.uint8)
+
+    def rule(grid, neighbor_count=None, num_states=2):
+        padded = np.pad(grid, pad_width=1, mode='wrap')
+        new_grid = np.zeros_like(grid)
+        for i in range(len(grid)):
+            left = padded[i]
+            center = padded[i + 1]
+            right = padded[i + 2]
+            index = (left << 2) | (center << 1) | right
+            new_grid[i] = binary[7 - index]
+        return new_grid
+
+    return rule
+
+def extract_features(history):
+    entropy_curve = temporal_entropy(history)
+    entropy_mean = np.mean(entropy_curve)
+    activity = activity_score(history)
+    symmetry = symmetry_score(history[-1])
+    return [entropy_mean, activity, symmetry]
+
+def main():
+    results = []
+    print("[*] Generating dataset for rules 0–255...")
+
+    for rule_num in range(256):
+        rule_fn = make_rule_fn(rule_num)
+        for run_id in range(5):  # multiple runs per rule
+            ca = CellularAutomaton(grid_size=101, rule_fn=rule_fn, dim=1)
+            history = ca.run(steps=100)
+            entropy, activity, symmetry = extract_features(history)
+            results.append({
+                "rule": rule_num,
+                "run": run_id,
+                "entropy": entropy,
+                "activity": activity,
+                "symmetry": symmetry
+            })
+
+    df = pd.DataFrame(results)
+    df.to_csv("data/elementary_rules_dataset.csv", index=False)
+    print(f"[✓] Dataset saved to data/elementary_rules_dataset.csv")
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/pattern_analysis.py
+++ b/scripts/pattern_analysis.py
@@ -1,0 +1,32 @@
+# scripts/pattern_analysis.py
+
+from src.ca_core import CellularAutomaton
+from src.models.game_of_life import game_of_life_rule
+from utils.visualize import plot_grid
+from utils.metrics import temporal_entropy, symmetry_score
+
+import matplotlib.pyplot as plt
+
+def main():
+    print("[*] Running Game of Life for 100 steps...")
+    ca = CellularAutomaton(grid_size=(50, 50), rule_fn=game_of_life_rule, dim=2)
+    history = ca.run(steps=100)
+
+    print("[*] Plotting entropy over time...")
+    entropies = temporal_entropy(history)
+    plt.plot(entropies)
+    plt.title("Entropy Over Time")
+    plt.xlabel("Step")
+    plt.ylabel("Shannon Entropy")
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+    print("[*] Computing symmetry of final grid...")
+    sym = symmetry_score(history[-1])
+    print(f"Final symmetry score: {sym:.2f}")
+    plot_grid(history[-1], title=f"Final Grid (Symmetry: {sym:.2f})")
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/visualize_behavior.py
+++ b/scripts/visualize_behavior.py
@@ -1,0 +1,40 @@
+# scripts/visualize_behavior_map.py
+
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.manifold import TSNE
+import umap
+from sklearn.preprocessing import StandardScaler
+
+def plot_embedding(emb, labels, title, color_key="rule"):
+    plt.figure(figsize=(8, 6))
+    scatter = plt.scatter(emb[:, 0], emb[:, 1], c=labels, cmap="viridis", s=50, edgecolor="k", alpha=0.8)
+    plt.title(title)
+    plt.xlabel("Dim 1")
+    plt.ylabel("Dim 2")
+    plt.grid(True)
+    plt.colorbar(scatter, label=color_key)
+    plt.tight_layout()
+    plt.show()
+
+def main():
+    df = pd.read_csv("data/elementary_rules_dataset.csv")
+    features = df[["entropy", "activity", "symmetry"]].values
+    labels = df["rule"].values
+
+    scaler = StandardScaler()
+    X = scaler.fit_transform(features)
+
+    # --- UMAP ---
+    print("[*] Running UMAP...")
+    umap_emb = umap.UMAP(n_neighbors=15, min_dist=0.1, metric="euclidean", random_state=42).fit_transform(X)
+    plot_embedding(umap_emb, labels, "CA Behavior Map (UMAP)", color_key="rule")
+
+    # --- t-SNE ---
+    print("[*] Running t-SNE...")
+    tsne_emb = TSNE(n_components=2, perplexity=30, random_state=42).fit_transform(X)
+    plot_embedding(tsne_emb, labels, "CA Behavior Map (t-SNE)", color_key="rule")
+
+if __name__ == "__main__":
+    main()
+

--- a/src/models/continuous_diffusion.py
+++ b/src/models/continuous_diffusion.py
@@ -1,0 +1,26 @@
+# src/models/continuous_diffusion.py
+
+import numpy as np
+from scipy.ndimage import convolve
+
+def continuous_diffusion_rule(grid, neighbor_count=None, num_states=None):
+    """
+    Each cell holds a float state between 0 and 1.
+    Update = diffusion + decay.
+
+    - Uses a 3x3 Gaussian-like kernel
+    - Models diffusion of a signal (e.g., morphogen or voltage)
+    """
+
+    kernel = np.array([
+        [0.05, 0.1, 0.05],
+        [0.1,  0.4, 0.1],
+        [0.05, 0.1, 0.05]
+    ])
+
+    diffused = convolve(grid, kernel, mode='wrap')
+    decayed = diffused * 0.98  # simple decay
+
+    # Clamp values to [0, 1]
+    return np.clip(decayed, 0, 1)
+

--- a/src/models/multistate_wave.py
+++ b/src/models/multistate_wave.py
@@ -1,0 +1,27 @@
+# src/models/multistate_wave.py
+
+import numpy as np
+
+def multistate_wave_rule(grid, neighbor_count, num_states):
+    """
+    A simple 3-state excitable medium rule:
+    - 0 = resting
+    - 1 = excited
+    - 2 = refractory
+
+    Rules:
+    - Resting cell becomes excited if >= 1 excited neighbor
+    - Excited → Refractory
+    - Refractory → Resting
+    """
+    new_grid = np.copy(grid)
+
+    excited_neighbors = (neighbor_count >= 1)
+
+    # Rule transitions
+    new_grid[(grid == 0) & excited_neighbors] = 1     # Resting → Excited
+    new_grid[(grid == 1)] = 2                         # Excited → Refractory
+    new_grid[(grid == 2)] = 0                         # Refractory → Resting
+
+    return new_grid
+

--- a/src/models/reaction_diffusion.py
+++ b/src/models/reaction_diffusion.py
@@ -1,0 +1,42 @@
+# src/models/reaction_diffusion.py
+
+import numpy as np
+from scipy.ndimage import convolve
+
+def reaction_diffusion_rule(grid, neighbor_count=None, num_states=None):
+    """
+    Gray-Scott-like reaction-diffusion system:
+    Two chemicals, U and V, diffuse and react:
+    - U diffuses slowly and feeds V
+    - V diffuses faster and decays
+
+    grid: 3D array of shape (H, W, 2) with channels [U, V]
+    """
+    U = grid[..., 0]
+    V = grid[..., 1]
+
+    # Diffusion kernels (Laplacian-style)
+    kernel = np.array([
+        [0.05, 0.2, 0.05],
+        [0.2, -1.0, 0.2],
+        [0.05, 0.2, 0.05]
+    ])
+
+    dU = convolve(U, kernel, mode='wrap')
+    dV = convolve(V, kernel, mode='wrap')
+
+    # Reaction-diffusion parameters (tweakable)
+    Du, Dv = 0.16, 0.8
+    F, k = 0.060, 0.062
+
+    # Gray-Scott reaction equations
+    reaction = U * V**2
+    U_new = U + (Du * dU - reaction + F * (1 - U))
+    V_new = V + (Dv * dV + reaction - (F + k) * V)
+
+    # Clamp values to [0, 1]
+    U_new = np.clip(U_new, 0, 1)
+    V_new = np.clip(V_new, 0, 1)
+
+    return np.stack([U_new, V_new], axis=-1)
+

--- a/utils/visualize.py
+++ b/utils/visualize.py
@@ -4,6 +4,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 import os
+import imageio
+from matplotlib import cm
 
 def plot_grid(grid, title="CA Grid", cmap="binary"):
     plt.figure(figsize=(6, 6))
@@ -50,8 +52,27 @@ def animate_history(history, interval=100, save_path=None, cmap="binary"):
 
     if save_path:
         ani.save(save_path, fps=1000 // interval)
+        print(f"[✓] Animation saved to {save_path}")
     else:
         plt.show()
 
     return ani
+
+def save_grid_as_image(grid, filename, cmap="viridis"):
+    """
+    Save a single CA grid as an image file.
+    """
+    plt.imsave(filename, grid, cmap=cmap)
+    print(f"[✓] Saved image to {filename}")
+
+def save_history_as_video(history, filename, cmap="viridis"):
+    """
+    Save CA evolution as a .mp4 or .gif animation.
+    """
+    norm = plt.Normalize(vmin=history.min(), vmax=history.max())
+    colormap = cm.get_cmap(cmap)
+
+    frames = [(colormap(norm(frame)) * 255).astype(np.uint8) for frame in history]
+    imageio.mimsave(filename, frames, fps=20)
+    print(f"[✓] Saved video to {filename}")
 


### PR DESCRIPTION
This PR adds `label_wolfram_classes.py`, a heuristic labeling script for assigning Wolfram Classes (I–IV) to CA rules.

- Based on entropy and activity thresholds
- Labels saved in new column `wolfram_class`
- Output written to `data/elementary_rules_labeled.csv`

Supports supervised learning, clustering validation, and visualization by class.
