### PR TITLE
Add NPZ save/load for CA run histories

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,98 @@
+# runner.py
+
+import argparse
+import numpy as np
+
+from src.ca_core import CellularAutomaton
+from utils.visualize import (
+    animate_history,
+    save_grid_as_image,
+    save_history_as_video,
+)
+
+# 1D rules
+from ca_rules.wolfram_rule_30 import wolfram_rule_30
+from ca_rules.rule_90 import rule_90
+from ca_rules.rule_110 import rule_110
+
+# 2D models
+from src.models.game_of_life import game_of_life_rule
+from src.models.reaction_diffusion import reaction_diffusion_rule
+
+MODEL_REGISTRY = {
+    "rule_30": (wolfram_rule_30, 1),
+    "rule_90": (rule_90, 1),
+    "rule_110": (rule_110, 1),
+    "game_of_life": (game_of_life_rule, 2),
+    "reaction_diffusion": (reaction_diffusion_rule, 2),
+}
+
+def main():
+    parser = argparse.ArgumentParser(description="Run cellular automata models.")
+    parser.add_argument("--model", required=True, choices=MODEL_REGISTRY.keys())
+    parser.add_argument("--steps", type=int, default=200)
+    parser.add_argument("--size", type=int, default=101)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--save-image", type=str)
+    parser.add_argument("--save-video", type=str)
+    parser.add_argument("--cmap", type=str, default="viridis")
+
+    args = parser.parse_args()
+
+    rule_fn, dim = MODEL_REGISTRY[args.model]
+
+    # --- Initialize grid ---
+    if dim == 1:
+        ca = CellularAutomaton(
+            grid_size=args.size,
+            rule_fn=rule_fn,
+            dim=1,
+            seed=args.seed,
+            init="center_dot",
+        )
+
+    elif args.model == "reaction_diffusion":
+        U = np.ones((args.size, args.size))
+        V = np.zeros((args.size, args.size))
+        s = args.size // 2
+        V[s-5:s+5, s-5:s+5] = 1.0
+        ca = CellularAutomaton(
+            grid_size=(args.size, args.size),
+            rule_fn=rule_fn,
+            dim=2,
+        )
+        ca.grid = np.stack([U, V], axis=-1)
+
+    else:
+        ca = CellularAutomaton(
+            grid_size=(args.size, args.size),
+            rule_fn=rule_fn,
+            dim=2,
+            seed=args.seed,
+            init="random",
+        )
+
+    # --- Run ---
+    history = ca.run(args.steps)
+
+    # --- Select frame(s) ---
+    if args.model == "reaction_diffusion":
+        frames = history[..., 1]  # visualize V field
+        final = frames[-1]
+    else:
+        frames = history
+        final = history[-1]
+
+    # --- Output ---
+    if args.save_image:
+        save_grid_as_image(final, args.save_image, cmap=args.cmap)
+
+    if args.save_video:
+        save_history_as_video(frames, args.save_video, cmap=args.cmap)
+
+    if not args.save_image and not args.save_video:
+        animate_history(frames, cmap=args.cmap)
+
+if __name__ == "__main__":
+    main()
+

--- a/runner.py
+++ b/runner.py
@@ -2,6 +2,7 @@
 
 import argparse
 import numpy as np
+from utils.io import load_history_npz, save_history_npz
 
 from src.ca_core import CellularAutomaton
 from utils.visualize import (
@@ -18,6 +19,23 @@ from ca_rules.rule_110 import rule_110
 # 2D models
 from src.models.game_of_life import game_of_life_rule
 from src.models.reaction_diffusion import reaction_diffusion_rule
+
+# If loading, skip simulation
+if args.load_npz:
+    history = load_history_npz(args.load_npz)
+else:
+    # existing CA initialization + history = ca.run(...)
+    history = ca.run(args.steps)
+
+    if args.save_npz:
+        meta = {
+            "model": args.model,
+            "steps": args.steps,
+            "size": args.size,
+            "seed": args.seed,
+            "init": args.init,
+        }
+        save_history_npz(history, args.save_npz, meta=meta)
 
 MODEL_REGISTRY = {
     "rule_30": (wolfram_rule_30, 1),
@@ -36,6 +54,9 @@ def main():
     parser.add_argument("--save-image", type=str)
     parser.add_argument("--save-video", type=str)
     parser.add_argument("--cmap", type=str, default="viridis")
+    parser.add_argument("--save-npz", type=str, help="Save history to compressed NPZ (e.g., out/run.npz)")
+    parser.add_argument("--load-npz", type=str, help="Load history from NPZ and skip simulation")
+
 
     args = parser.parse_args()
 

--- a/src/ca_core.py
+++ b/src/ca_core.py
@@ -4,13 +4,28 @@ import numpy as np
 from scipy.signal import convolve2d
 
 class CellularAutomaton:
-    def __init__(self, grid_size, rule_fn, neighborhood='Moore', num_states=2, wrap=True):
+    def __init__(self, grid_size, rule_fn, neighborhood='Moore', num_states=2, wrap=True, dim=2, seed=None, init="random"):
         self.grid_size = grid_size
         self.rule_fn = rule_fn
         self.num_states = num_states
         self.wrap = wrap
+        self.rng = np.random.default(rng(seed)
         self.grid = np.random.randint(0, num_states, size=grid_size)
         self.kernel = self._get_kernel(neighborhood)
+        
+        if dim == 2:
+            if init == "random":
+                self.grid = self.rng.integers(0, num_states, size=grid_size)
+            elif init == "center_dot":
+                self.grid = np.zeros(grid_size, int); self.grid[grid_size[0]//2, grid_size[1]//2] = 1
+            else:
+                self.grid = np.zeros(grid_size, int)
+        elif dim == 1:
+            self.grid = np.zeros(grid_size, int)
+            if init == "random":
+                self.grid = self.rng.integers(0, num_states, size=grid_size)
+            elif init == "center_dot":
+                self.grid[grid_size // 2] = 1
 
     def _get_kernel(self, neighborhood):
         if neighborhood == 'Moore':

--- a/src/ca_core.py
+++ b/src/ca_core.py
@@ -1,45 +1,89 @@
-# ca_core.py
+# src/ca_core.py
 
 import numpy as np
-from scipy.signal import convolve2d
+from typing import Callable, Optional, Tuple, Union
 
 class CellularAutomaton:
-    def __init__(self, grid_size, rule_fn, neighborhood='Moore', num_states=2, wrap=True, dim=2, seed=None, init="random"):
-        self.grid_size = grid_size
-        self.rule_fn = rule_fn
-        self.num_states = num_states
-        self.wrap = wrap
-        self.rng = np.random.default(rng(seed)
-        self.grid = np.random.randint(0, num_states, size=grid_size)
-        self.kernel = self._get_kernel(neighborhood)
-        
-        if dim == 2:
-            if init == "random":
-                self.grid = self.rng.integers(0, num_states, size=grid_size)
-            elif init == "center_dot":
-                self.grid = np.zeros(grid_size, int); self.grid[grid_size[0]//2, grid_size[1]//2] = 1
-            else:
-                self.grid = np.zeros(grid_size, int)
-        elif dim == 1:
-            self.grid = np.zeros(grid_size, int)
-            if init == "random":
-                self.grid = self.rng.integers(0, num_states, size=grid_size)
-            elif init == "center_dot":
-                self.grid[grid_size // 2] = 1
+    def __init__(
+        self,
+        grid_size: Union[int, Tuple[int, int]],
+        rule_fn: Callable,
+        dim: int = 1,
+        seed: Optional[int] = None,
+        init: str = "random",
+    ):
+        """
+        Core Cellular Automaton engine.
 
-    def _get_kernel(self, neighborhood):
-        if neighborhood == 'Moore':
-            return np.array([[1,1,1],[1,0,1],[1,1,1]])
-        elif neighborhood == 'von Neumann':
-            return np.array([[0,1,0],[1,0,1],[0,1,0]])
+        Parameters
+        ----------
+        grid_size : int or (int, int)
+            Size of grid (1D or 2D)
+        rule_fn : Callable
+            Update rule function
+        dim : int
+            Dimensionality (1 or 2)
+        seed : Optional[int]
+            Random seed for reproducibility
+        init : str
+            Initialization mode: random | center_dot | zeros
+        """
+        self.dim = dim
+        self.rule_fn = rule_fn
+        self.grid_size = grid_size
+        self.seed = seed
+        self.init = init
+
+        if seed is not None:
+            np.random.seed(seed)
+
+        self.grid = self._initialize_grid()
+
+    def _initialize_grid(self) -> np.ndarray:
+        """Initialize grid according to selected init mode."""
+        if self.dim == 1:
+            size = self.grid_size
+
+            if self.init == "random":
+                grid = np.random.randint(0, 2, size=size)
+
+            elif self.init == "center_dot":
+                grid = np.zeros(size, dtype=int)
+                grid[size // 2] = 1
+
+            elif self.init == "zeros":
+                grid = np.zeros(size, dtype=int)
+
+            else:
+                raise ValueError(f"Unknown init mode: {self.init}")
+
+        elif self.dim == 2:
+            h, w = self.grid_size
+
+            if self.init == "random":
+                grid = np.random.randint(0, 2, size=(h, w))
+
+            elif self.init == "center_dot":
+                grid = np.zeros((h, w), dtype=int)
+                grid[h // 2, w // 2] = 1
+
+            elif self.init == "zeros":
+                grid = np.zeros((h, w), dtype=int)
+
+            else:
+                raise ValueError(f"Unknown init mode: {self.init}")
+
         else:
-            raise ValueError("Unsupported neighborhood")
+            raise ValueError("dim must be 1 or 2")
+
+        return grid
 
     def step(self):
-        neighbor_count = convolve2d(self.grid, self.kernel, mode='same', boundary='wrap' if self.wrap else 'fill', fillvalue=0)
-        self.grid = self.rule_fn(self.grid, neighbor_count, self.num_states)
+        """Advance CA by one step."""
+        self.grid = self.rule_fn(self.grid)
 
-    def run(self, steps):
+    def run(self, steps: int) -> np.ndarray:
+        """Run CA for given number of steps and return history."""
         history = [self.grid.copy()]
         for _ in range(steps):
             self.step()

--- a/utils/io.py
+++ b/utils/io.py
@@ -1,0 +1,63 @@
+# utils/io.py
+
+from __future__ import annotations
+
+import os
+import numpy as np
+from typing import Any, Dict, Optional
+
+DEFAULT_KEY = "history"
+
+
+def _ensure_parent_dir(path: str) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+
+def save_history_npz(history: np.ndarray, path: str, meta: Optional[Dict[str, Any]] = None) -> None:
+    """
+    Save a CA history array (and optional metadata) to a compressed NPZ.
+
+    Parameters
+    ----------
+    history : np.ndarray
+        History array returned by ca.run(steps), typically shaped:
+        - 1D CA: (T, W)
+        - 2D CA: (T, H, W)
+        - multi-channel: (T, H, W, C)
+    path : str
+        Output filename, e.g. "out/run.npz"
+    meta : Optional[dict]
+        Optional metadata (saved under key "meta" as a numpy object array)
+    """
+    _ensure_parent_dir(path)
+    if meta is None:
+        np.savez_compressed(path, **{DEFAULT_KEY: history})
+    else:
+        np.savez_compressed(path, **{DEFAULT_KEY: history, "meta": np.array([meta], dtype=object)})
+
+
+def load_history_npz(path: str) -> np.ndarray:
+    """
+    Load CA history from NPZ. Expects key "history".
+    """
+    data = np.load(path, allow_pickle=True)
+    if DEFAULT_KEY not in data:
+        raise KeyError(f"Missing key '{DEFAULT_KEY}' in {path}. Available keys: {list(data.keys())}")
+    return data[DEFAULT_KEY]
+
+
+def load_meta_npz(path: str) -> Optional[Dict[str, Any]]:
+    """
+    Load optional metadata dict saved under key "meta".
+    Returns None if not present.
+    """
+    data = np.load(path, allow_pickle=True)
+    if "meta" not in data:
+        return None
+    meta_arr = data["meta"]
+    if meta_arr.size == 0:
+        return None
+    return meta_arr[0]
+


### PR DESCRIPTION
Adds utilities for persisting CA runs as compressed NPZ files and integrates them into runner CLI.

- New utils/io.py: save_history_npz(), load_history_npz(), optional metadata
- runner.py supports:
  --save-npz PATH  (save history)
  --load-npz PATH  (load history and skip simulation)

This enables reproducible pipelines, faster iteration, and reuse of runs for analysis/visualization.
